### PR TITLE
Fix hang after calling `SaeTrainer.save()` w/ DDP

### DIFF
--- a/sae/trainer.py
+++ b/sae/trainer.py
@@ -304,7 +304,7 @@ class SaeTrainer:
                 print(f"Saving layer {i}")
 
                 path = self.cfg.run_name or "checkpoints"
-                sae.save_to_disk(f"{path}/layer_{i}.pt")
+                sae.save_to_disk(f"{path}/layer_{i}")
 
         # Barrier to ensure all ranks have saved before continuing
         dist.barrier()

--- a/sae/trainer.py
+++ b/sae/trainer.py
@@ -295,15 +295,17 @@ class SaeTrainer:
 
     def save(self):
         """Save the SAEs to disk."""
-        if (dist.is_initialized() and dist.get_rank() != 0) and not self.cfg.distribute_layers:
+
+        if not dist.is_initialized():
             return
 
-        for i, sae in zip(self.cfg.layers, self.saes):
-            assert isinstance(sae, Sae)
-            print(f"Saving layer {i}")
+        if self.cfg.distribute_layers or dist.get_rank() == 0:
+            for i, sae in zip(self.cfg.layers, self.saes):
+                assert isinstance(sae, Sae)
+                print(f"Saving layer {i}")
 
-            path = self.cfg.run_name or "checkpoints"
-            sae.save_to_disk(f"{path}/layer_{i}.pt")
+                path = self.cfg.run_name or "checkpoints"
+                sae.save_to_disk(f"{path}/layer_{i}.pt")
 
         # Barrier to ensure all ranks have saved before continuing
         dist.barrier()

--- a/sae/trainer.py
+++ b/sae/trainer.py
@@ -295,10 +295,7 @@ class SaeTrainer:
     def save(self):
         """Save the SAEs to disk."""
 
-        if not dist.is_initialized():
-            return
-
-        if self.cfg.distribute_layers or dist.get_rank() == 0:
+        if self.cfg.distribute_layers or dist.get_rank() == 0 or not dist.is_initialized():
             for i, sae in zip(self.cfg.layers, self.saes):
                 assert isinstance(sae, Sae)
                 print(f"Saving layer {i}")
@@ -307,4 +304,5 @@ class SaeTrainer:
                 sae.save_to_disk(f"{path}/layer_{i}")
 
         # Barrier to ensure all ranks have saved before continuing
-        dist.barrier()
+        if dist.is_initialized():
+            dist.barrier()

--- a/sae/trainer.py
+++ b/sae/trainer.py
@@ -295,7 +295,7 @@ class SaeTrainer:
     def save(self):
         """Save the SAEs to disk."""
 
-        if self.cfg.distribute_layers or dist.get_rank() == 0 or not dist.is_initialized():
+        if self.cfg.distribute_layers or not dist.is_initialized() or dist.get_rank() == 0:
             for i, sae in zip(self.cfg.layers, self.saes):
                 assert isinstance(sae, Sae)
                 print(f"Saving layer {i}")


### PR DESCRIPTION
While trying to train with DDP on an 8xA100 node with default arguments...

```bash
torchrun --nproc_per_node gpu -m sae EleutherAI/pythia-160m togethercomputer/RedPajama-Data-1T-Sample --attn_implementation=eager
```

...the trainer hangs after saving--the layers are successfully saved, but afterwards the trainer doesn't make progress and stays stuck on iteration 999.

Running with `TORCH_DISTRIBUTED_DEBUG=DETAIL`, when a normal run would've hung, the trainer instead crashes with a process desync exception, saying rank 0 is in a barrier while the others have moved on to reduce. (Unfortunately I didn't save the exact exception, if it'd be useful I can undo my fix and get it.)

I believe the error is in `trainer.py:save`:

https://github.com/EleutherAI/sae/blob/2cc21c8ad11140209c725de68219ccfc5cea2c18/sae/trainer.py#L296-L309

The first `if` causes the other processes to leave the function immediately, so only rank 0 hits the barrier, causing the desync. After changing `save` to remove the early return, so that all processes reach `dist.barrier()`, training now passes the savepoint without issue.