### PR TITLE
Fix model download issue

### DIFF
--- a/sae/sae.py
+++ b/sae/sae.py
@@ -99,11 +99,11 @@ class Sae(nn.Module):
         # Download from the HuggingFace Hub
         repo_path = Path(
             snapshot_download(
-                name, allow_patterns=f"layer_{layer}/*" if layer is not None else None,
+                name, allow_patterns=f"layers.{layer}/*" if layer is not None else None,
             )
         )
         if layer is not None:
-            repo_path = repo_path / f"layer_{layer}"
+            repo_path = repo_path / f"layers.{layer}"
 
         # No layer specified, and there are multiple layers
         elif not repo_path.joinpath("cfg.json").exists():


### PR DESCRIPTION
## Description
This pull request addresses a bug that caused model download functionality `Sae.load_from_hub("EleutherAI/sae-llama-3-8b-32x", layer=10)` to fail. The issue arose due to a folder name change in the Huggingface repository. Ref: [huggingface commit](https://huggingface.co/EleutherAI/sae-llama-3-8b-32x/commit/32926540825db694b6228df703f4528df4793d67).

## Changes Made
`layer_` to `layers.` in **sae/sae.py**

## Testing
Ran the model download process with the updated code without errors.