### PR TITLE
add installation and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,24 @@ torchrun --nproc_per_node gpu -m sae meta-llama/Meta-Llama-3-8B --distribute_lay
 
 The above command trains an SAE for every _even_ layer of Llama 3 8B, using all available GPUs. It accumulates gradients over 8 minibatches, and splits each minibatch into 2 microbatches before feeding them into the SAE encoder, thus saving a lot of memory. It also loads the model in 8-bit precision using `bitsandbytes`. This command requires no more than 48GB of memory per GPU on an 8 GPU node.
 
+## Installation
+
+To install python dependencies
+
+```bash
+pip install .
+```
+
+[triton](https://github.com/triton-lang/triton) is an optional dependency of this project to make the sparse Autoencoder more efficient but it is not included in `pyproject.toml` because triton is not officially supported on Windows or MacOS. To benefit from triton kernels on a Linux system install triton separately with `pip install triton`.
+
+## Testing
+
+Install pytest with `pip install pytest` and run the tests
+
+```bash
+python -m pytest tests
+```
+
 ## TODO
 
 There are several features that we'd like to add in the near future:

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,8 +1,11 @@
 from sae.utils import eager_decode, triton_decode
 import torch
-
+import pytest
 
 def test_decode():
+    if not torch.cuda.is_available():
+        pytest.skip("This test requires a GPU to run.")
+        
     batch = 2
     d_in = 50
     d_sae = 100


### PR DESCRIPTION
following on from #6 adding the installation instructions as mentioned

also explicitly informing users that they will need to install triton separately if they want its benefits since it is no longer in `pyproject.toml`