### PR TITLE
fix bug in load many and support load multiple selected layers

### DIFF
--- a/sae/sae.py
+++ b/sae/sae.py
@@ -63,7 +63,7 @@ class Sae(nn.Module):
         self.b_dec = nn.Parameter(torch.zeros(d_in, dtype=dtype, device=device))
 
     @staticmethod
-    def load_many_from_hub(
+    def load_many(
         name: str,
         local: bool = False,
         layers: list[str] | None = None,

--- a/sae/sae.py
+++ b/sae/sae.py
@@ -133,7 +133,6 @@ class Sae(nn.Module):
             cfg = SaeConfig(**cfg_dict)
 
         sae = Sae(d_in, cfg, device=device, decoder=decoder)
-        print(f"Loading SAE from {path}")
         load_model(
             model=sae,
             filename=str(path / "sae.safetensors"),

--- a/sae/sae.py
+++ b/sae/sae.py
@@ -65,6 +65,8 @@ class Sae(nn.Module):
     @staticmethod
     def load_many_from_hub(
         name: str,
+        local: bool = False,
+        layers: list[str] | None = None,
         device: str | torch.device = "cpu",
         *,
         decoder: bool = True,
@@ -72,16 +74,24 @@ class Sae(nn.Module):
     ) -> dict[str, "Sae"]:
         """Load SAEs for multiple hookpoints on a single model and dataset."""
         pattern = pattern + "/*" if pattern is not None else None
-        repo_path = Path(snapshot_download(name, allow_patterns=pattern))
+        if local:
+            repo_path = Path(name)
+        else:
+            repo_path = Path(snapshot_download(name, allow_patterns=pattern))
 
+        if layers is not None:
+            return {
+                layer: Sae.load_from_disk(repo_path / layer, device=device, decoder=decoder)
+                for layer in natsorted(layers)
+            }
         files = [
             f
             for f in repo_path.iterdir()
             if f.is_dir() and (pattern is None or fnmatch(f.name, pattern))
         ]
         return {
-            f.stem: Sae.load_from_disk(f, device=device, decoder=decoder)
-            for f in natsorted(files, key=lambda f: f.stem)
+            f.name: Sae.load_from_disk(f, device=device, decoder=decoder)
+            for f in natsorted(files, key=lambda f: f.name)
         }
 
     @staticmethod
@@ -123,6 +133,7 @@ class Sae(nn.Module):
             cfg = SaeConfig(**cfg_dict)
 
         sae = Sae(d_in, cfg, device=device, decoder=decoder)
+        print(f"Loading SAE from {path}")
         load_model(
             model=sae,
             filename=str(path / "sae.safetensors"),


### PR DESCRIPTION
 - Fixed load multiple layers bug:
After changing the layer folder name to "layer.x", path.stem will return "layer" instead of "layer.x". Changed to path.name to return "layer.x" for loading correctly.

- Support loading only selected layers
Pass layer name in the format of string in order to load multiple layers, like ["layers.0", "embed_tokens", "layers.1"]. 
Not sure about the documentation norm of this project, so I did not insert explanation in the codes.

- Support loading from local path instead of hub.
 
 