### PR TITLE
Make loss more like standard MSE loss

### DIFF
--- a/sae/sae.py
+++ b/sae/sae.py
@@ -200,7 +200,7 @@ class Sae(nn.Module):
         e = sae_out - x
 
         # Used as a denominator for putting everything on a reasonable scale
-        total_variance = (x - x.mean(0)).pow(2).sum(0)
+        total_variance = (x - x.mean(0)).pow(2).sum()
 
         # Second decoder pass for AuxK loss
         if dead_mask is not None and (num_dead := int(dead_mask.sum())) > 0:
@@ -220,13 +220,13 @@ class Sae(nn.Module):
             # Encourage the top ~50% of dead latents to predict the residual of the
             # top k living latents
             e_hat = self.decode(auxk_acts, auxk_indices)
-            auxk_loss = (e_hat - e).pow(2).sum(0)
-            auxk_loss = scale * torch.mean(auxk_loss / total_variance)
+            auxk_loss = (e_hat - e).pow(2).sum()
+            auxk_loss = scale * auxk_loss / total_variance
         else:
             auxk_loss = sae_out.new_tensor(0.0)
 
-        l2_loss = e.pow(2).sum(0)
-        fvu = torch.mean(l2_loss / total_variance)
+        l2_loss = e.pow(2).sum()
+        fvu = l2_loss / total_variance
 
         return ForwardOutput(
             sae_out,


### PR DESCRIPTION
In computing our FVU loss we had been separately normalizing each coordinate of the hidden state by the minibatch variance along that coordinate, which is not equivalent to the standard MSE loss. Jacob Drori pointed out that this privileges the standard basis, which may be viewed as a defect, although empirically transformers [do show evidence](https://www.anthropic.com/research/privileged-bases-in-the-transformer-residual-stream) of "privileging" the standard basis. There are also reasons to worry that MSE may put too much emphasis on [rogue dimensions](https://arxiv.org/abs/2109.04404) of very high variance. That said, preliminary tests indicate that our old loss and the MSE loss yield SAEs with nearly identical cross entropies when patched into the model, and since MSE is more commonly used, we're switching to that for now.