### PR TITLE
Added back in "signed" property of SaeConfig to support loading older weights

### DIFF
--- a/sae/config.py
+++ b/sae/config.py
@@ -24,7 +24,9 @@ class SaeConfig(Serializable):
     multi_topk: bool = False
     """Use Multi-TopK loss."""
 
-
+    signed: bool = False
+    """DEPRECATED. Still needed for loading of legacy weights"""
+    
 @dataclass
 class TrainConfig(Serializable):
     sae: SaeConfig


### PR DESCRIPTION
SAE weights such as EleutherAI/sae-llama-3-8b-32x and EleutherAI/sae-llama-3-8b-32x-v2 still have the "signed" parameter in their config file. Removing this property from the SaeConfig, results in an error during loading these weights. 

Added back in this config property.