### PR TITLE
Support using multiple random seeds for init

### DIFF
--- a/sae/__main__.py
+++ b/sae/__main__.py
@@ -56,7 +56,7 @@ class RunConfig(TrainConfig):
     finetune: str | None = None
     """Path to pretrained SAEs to finetune."""
 
-    seed: int = 42
+    shuffle_seed: int = 42
     """Random seed for shuffling the dataset."""
 
     data_preprocessing_num_proc: int = field(
@@ -120,8 +120,8 @@ def load_artifacts(
         else:
             print("Dataset already tokenized; skipping tokenization.")
 
-        print(f"Shuffling dataset with seed {args.seed}")
-        dataset = dataset.shuffle(args.seed)
+        print(f"Shuffling dataset with seed {args.shuffle_seed}")
+        dataset = dataset.shuffle(args.shuffle_seed)
 
         dataset = dataset.with_format("torch")
         if limit := args.max_examples:

--- a/sae/config.py
+++ b/sae/config.py
@@ -55,6 +55,10 @@ class TrainConfig(Serializable):
     hookpoints: list[str] = list_field()
     """List of hookpoints to train SAEs on."""
 
+    init_seeds: list[int] = list_field(0)
+    """List of random seeds to use for initialization. If more than one, train an SAE
+    for each seed."""
+
     layers: list[int] = list_field()
     """List of layer indices to train SAEs on."""
 

--- a/sae/config.py
+++ b/sae/config.py
@@ -82,3 +82,5 @@ class TrainConfig(Serializable):
         assert not (
             self.layers and self.layer_stride != 1
         ), "Cannot specify both `layers` and `layer_stride`."
+
+        assert len(self.init_seeds) > 0, "Must specify at least one random seed."


### PR DESCRIPTION
This PR adds an `init_seeds` config option which allows you to set one or more random seeds to use for initializing the SAEs. When you provide more than one, _multiple SAEs will be trained for each hookpoint_, one for each seed given. This is more efficient than separately running SAE training for each seed, since the hidden states are reused.

Other changes:
- By default, `init_seeds` is a singleton list containing `0`, which means the SAE init process is now seeded and deterministic, which it wasn't before.
- The same seed is used to initialize all hookpoints. This means that all hookpoints with the same number of features should get SAEs with exactly the same initialization(s). So SAEs trained on adjacent layers of the residual stream, for example, should be roughly "aligned" out of the box, without needing to run the Hungarian algorithm to permute their latents into alignment.